### PR TITLE
Don't use full path to /usr/sbin/opendkim-genkey

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     - restart opendkim
 
 - name: Generate signing key
-  command: /usr/sbin/opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domains[0] }} -D /etc/opendkim/keys
+  command: opendkim-genkey -s {{ dkim_selector }} -d {{ dkim_domains[0] }} -D /etc/opendkim/keys
   args:
     creates: "/etc/opendkim/keys/{{ dkim_selector }}.private"
     warn: false


### PR DESCRIPTION
On Ubuntu 16.04.5 LTS the path is in /usr/bin rather than /usr/sbin